### PR TITLE
Use the golang container for CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
 
     # Run the tests inside the container so they have direct access to the service containers.
     container:
-      image:  node:17
+      image:  node:17-alpine
 
     services:
       # The database provider is needed to spawn database instances for

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
 
     # Run the tests inside the container so they have direct access to the service containers.
     container:
-      image:  node:17-alpine
+      image:  golang:1.17-alpine
 
     services:
       # The database provider is needed to spawn database instances for

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
 
     # Run the tests inside the container so they have direct access to the service containers.
     container:
-      image:  golang:1.17-alpine
+      image:  golang:1.17
 
     services:
       # The database provider is needed to spawn database instances for

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,10 +40,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.17
+    # There is no need for us to explicitly set up Go because we're using the Golang container image.
+    # - name: Set up Go
+    #  uses: actions/setup-go@v2
+    #  with:
+    #    go-version: 1.17
 
     # Keep this around (but commented) because it can be useful to debug if the service is failing.
     # - name: Show logs


### PR DESCRIPTION
The old one we were using was over 300MB which is way more than we need to run these Go tests.