### PR TITLE
Change the way the service handles the database not ready.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -66,3 +66,12 @@ jobs:
       # Run all unit tests plus integration tests. We can safely run integration tests because
       # we set up the necessary service containers.
       run: go test -v ./... -tags=integration
+
+    - name: Install Bazel
+      uses: bazelbuild/setup-bazelisk@v1
+
+    # Make sure the Bazel toolchain works successfully.
+    - name: Bazel Build & Test
+      run: |
+        bazel test //... \
+          --test_env=DB_INSTANCE_PROVIDER_ADDRESS=provider:58615

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,13 +18,13 @@ jobs:
       # The database provider is needed to spawn database instances for
       # unit integration tests.
       database:
-        image: mysql/mysql-server:8.0
+        image: mysql:8.0
         env:
           MYSQL_ROOT_PASSWORD: test
           MYSQL_ROOT_HOST: "%"
 
       provider:
-        image: karagog/mysql-db-provider:latest
+        image: karagog/mysql-db-provider:dev
         env:
           MYSQL_ROOT_PASSWORD: test
           MYSQL_ROOT_HOST: "%"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,4 @@
-name: Go
+name: Regression Test
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  test-job:
+  regression-test:
     runs-on: ubuntu-latest
 
     # Run the tests inside the container so they have direct access to the service containers.
@@ -39,6 +39,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: Install Ubuntu Packages
+      run: |
+        apt-get update
+        apt-get install -y \
+          patch
 
     # There is no need for us to explicitly set up Go because we're using the Golang container image.
     # - name: Set up Go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,7 +44,9 @@ jobs:
       run: |
         apt-get update
         apt-get install -y \
-          patch
+          build-essential \
+          patch \
+          python-is-python3
 
     # There is no need for us to explicitly set up Go because we're using the Golang container image.
     # - name: Set up Go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ jobs:
           MYSQL_ROOT_HOST: "%"
 
       provider:
-        image: karagog/mysql-db-provider:dev
+        image: karagog/mysql-db-provider:latest
         env:
           MYSQL_ROOT_PASSWORD: test
           MYSQL_ROOT_HOST: "%"
@@ -40,6 +40,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    # Some extra packages are required, for example when running bazel build.
     - name: Install Ubuntu Packages
       run: |
         apt-get update

--- a/client/go/database/database_test.go
+++ b/client/go/database/database_test.go
@@ -28,9 +28,7 @@ func TestDatabase(t *testing.T) {
 			},
 		},
 	}
-	svc := &service.Service{
-		Clock: simulated.NewClock(time.Now()),
-	}
+	svc := service.New(simulated.NewClock(time.Now()))
 	l := lessor.New(provider, 1)
 	svc.SetLessor(l)
 	ctx := context.Background()

--- a/containers/mysql/provider/main.go
+++ b/containers/mysql/provider/main.go
@@ -36,9 +36,7 @@ func main() {
 	}
 
 	// Start up the server.
-	svc := &service.Service{
-		Clock: simulated.NewClock(time.Now()),
-	}
+	svc := service.New(simulated.NewClock(time.Now()))
 	r, err := runner.New(svc, fmt.Sprintf(":%d", port))
 	if err != nil {
 		glog.Fatal(err)

--- a/server/lease/lease_test.go
+++ b/server/lease/lease_test.go
@@ -19,9 +19,7 @@ func fakeServiceRunner(numInstances int, t *testing.T) *runner.Runner {
 	l := lessor.New(&fake.DatabaseProvider{}, numInstances)
 	go l.Run(context.Background())
 
-	svc := &service.Service{
-		Clock: simulated.NewClock(time.Now()),
-	}
+	svc := service.New(simulated.NewClock(time.Now()))
 	svc.SetLessor(l)
 	r, err := runner.New(svc, "localhost:0")
 	if err != nil {

--- a/server/service/runner/runner_test.go
+++ b/server/service/runner/runner_test.go
@@ -16,9 +16,7 @@ import (
 
 func TestRunner(t *testing.T) {
 	// Initialize a fake service for testing.
-	svc := &service.Service{
-		Clock: simulated.NewClock(time.Now()),
-	}
+	svc := service.New(simulated.NewClock(time.Now()))
 	l := lessor.New(&fake.DatabaseProvider{}, 1)
 	svc.SetLessor(l)
 	ctx := context.Background()

--- a/server/service/service_test.go
+++ b/server/service/service_test.go
@@ -55,7 +55,7 @@ func startServer(t *testing.T) (ctl *serverCtl, stop func()) {
 		l.Run(lessorCtx)
 	}()
 
-	svc := &Service{Clock: c}
+	svc := New(c)
 	pb.RegisterIntegrationTestServer(s, svc)
 	shuttingDown := false
 	done := make(chan bool)
@@ -199,14 +199,14 @@ func TestGetDatabaseInstance(t *testing.T) {
 }
 
 // This tests what happens if you query for a database before the provider
-// has been fully initialized.
+// has been fully initialized: it should block indefinitely.
 func TestServerNotReady(t *testing.T) {
 	server, stop := startServer(t)
 	defer stop()
 
 	c := doGetDatabaseInstance(server.serviceAddr, t)
 	go c.Run()
-	c.AssertError("", nil, t)
+	c.AssertNoResponse("", t)
 }
 
 func TestServerDisconnect(t *testing.T) {


### PR DESCRIPTION
Previously it relied on the user retrying the RPC when it failed. Now it
blocks the RPC indefinitely until the database is ready.

This obviates the need for the health check, which we should remove in a
subsequent PR.